### PR TITLE
Profile Masking

### DIFF
--- a/Source/hoc-clk/common/include/hocclk/config.h
+++ b/Source/hoc-clk/common/include/hocclk/config.h
@@ -56,6 +56,7 @@ typedef enum {
     HocClkConfigValue_DVFSOffset,
     HocClkConfigValue_LiveCpuUv,
     HocClkConfigValue_EnableExperimentalSettings,
+    HocClkConfigValue_HiddenProfilesMask,
 
     HocClkConfigValue_GPUScheduling,
     HocClkConfigValue_GPUSchedulingMethod,
@@ -291,6 +292,9 @@ static inline const char* hocclkFormatConfigValue(HocClkConfigValue val, bool pr
 
         case HocClkConfigValue_EnableExperimentalSettings:
             return pretty ? "Enable Experimental Settings" : "enable_experimental_settings";
+        
+        case HocClkConfigValue_HiddenProfilesMask:
+            return pretty ? "Hidden Profiles Mask" : "hidden_profiles_mask";
 
         case HocClkConfigValue_RAMVoltDisplayMode:
             return pretty ? "RAM Voltage / Usage Display Mode" : "ram_volt_usage_display_mode";
@@ -555,6 +559,8 @@ static inline uint64_t hocclkDefaultConfigValue(HocClkConfigValue val)
             return 0ULL;
         case HocClkConfigValue_RamDisplayUnit:
             return (uint64_t)RamDisplayUnit_MHz;
+        case HocClkConfigValue_HiddenProfilesMask:
+            return 2ULL;
         case HocClkConfigValue_EristaMaxCpuClock:
             return 1785ULL;
 

--- a/Source/hoc-clk/overlay/src/ui/gui/app_profile_gui.cpp
+++ b/Source/hoc-clk/overlay/src/ui/gui/app_profile_gui.cpp
@@ -350,8 +350,17 @@ void AppProfileGui::addProfileUI(HocClkProfile profile)
         FatalGui::openWithResultCode("hocclkIpcGetConfigValues", rc);
         return;
     }
-    if((profile == HocClkProfile_Docked && IsHoag()) || profile == HocClkProfile_HandheldCharging)
+    if(profile == HocClkProfile_Docked && IsHoag())
         return;
+    uint32_t mask = configList.values[HocClkConfigValue_HiddenProfilesMask];
+    if((mask & (1 << profile))) {
+        bool profilePopulated = this->profileList->mhzMap[profile][HocClkModule_CPU] != 0 || 
+                                this->profileList->mhzMap[profile][HocClkModule_GPU] != 0 || 
+                                this->profileList->mhzMap[profile][HocClkModule_MEM] != 0 ||
+                                this->profileList->mhzMap[profile][HocClkModule_Governor] != 0;  
+        if(!profilePopulated)
+            return;
+    }
     this->listElement->addItem(new tsl::elm::CategoryHeader(hocclkFormatProfile(profile, true) + std::string(" ") + ult::DIVIDER_SYMBOL + " \ue0e3 Reset"));
     this->addModuleListItem(profile, HocClkModule_CPU);
     this->addModuleListItem(profile, HocClkModule_GPU);


### PR DESCRIPTION
This makes the hidden profiles configurable, instead of hiding specifically HandheldCharging.
It also doesn't hide if any of the fields are populated, preventing a scenario where clocks are set without the ability to see/change them from the overlay. Switch lite is still special cased.